### PR TITLE
Improved code size and performance: one shot

### DIFF
--- a/test.js
+++ b/test.js
@@ -33,6 +33,7 @@ try {
 catch (_) {}
 
 console.log('w/out reviver:', JSON.parse(JSON.stringify(value, ['bigint'])));
+console.log('with reviver:', JSON.parse(JSON.stringify(value, ['bigint']), JSON.reviver));
 
 // const s = JSON.rawJSON(JSON.stringify('Hello "there"!'));
 // JSON.parse(JSON.stringify({ s }), (key, value, context) => { console.log({ key, value, context }); return value });


### PR DESCRIPTION
The goal of this MR is to reduce code size down to 90 LOC and improve performance:

  * single RegExp VS 3 parses + array access
  * ignored keys while keeping parsing safe (all strings matched)
  * reduced memory usage on `parse`

Also tests VS native (Node) are there for comparison: a win-win all over the place? 🥳