### PR TITLE
Add defensive args parsing to stop FUD around this module

### DIFF
--- a/test.js
+++ b/test.js
@@ -35,5 +35,19 @@ catch (_) {}
 console.log('w/out reviver:', JSON.parse(JSON.stringify(value, ['bigint'])));
 console.log('with reviver:', JSON.parse(JSON.stringify(value, ['bigint']), JSON.reviver));
 
+console.assert(JSON.stringify({ a: 1, b: 2 }, {
+  apply() {
+    console.log('APPLY');
+  },
+  call() {
+    console.log('CALL');
+  }
+}) === '{"a":1,"b":2}');
+
+console.assert(JSON.stringify({ a: 1, b: 2 }, null) === '{"a":1,"b":2}');
+
+console.assert(JSON.stringify({ a: 1, b: 2 }, (_, v) => v) === '{"a":1,"b":2}');
+
+
 // const s = JSON.rawJSON(JSON.stringify('Hello "there"!'));
 // JSON.parse(JSON.stringify({ s }), (key, value, context) => { console.log({ key, value, context }); return value });


### PR DESCRIPTION
In this unfortunate thread https://github.com/mdn/content/pull/36294#issuecomment-2407752579 has been brought up the fact this *ungap* module is not 100% compliant with native *JSON* behavior.

Even if it's stated at the top of the [ungap documentation](https://github.com/ungap/ungap.github.io?tab=readme-ov-file#-pragmatic-is-better-than-imperfect) that this project doesn't care about paranoia or irrelevant (slow, bloated, etc) extra checks are often not part of the offer:

> The main purpose of this project is to help developers move forward, and possibly without unnecessary bloat. This basically means that polyfills are written to support 99% of the use cases, without granting 100% spec compliance.

it was extremely trivial to make it 100% specs compliant and as resilient as `core-js` counterpart by using (and trapping) once `Reflect.apply` to guarantee that even in poisoned environment, if this module is imported soon enough everything will just work as expected.

## Changes

  * strictly check `reviver` and `replacer` to reflect current native *JSON* expectations
  * trap once and use `Reflect.apply` to be sure tainted envs can't intercept json values

## TODO

  * there are other prototype methods that could be poisoned so that I might just drop *Reflect.apply* if I find it way slower than just `.call` and `.apply` when appropriate ... it's not the goal of this module to be super defensive about everything because even in `core-js` if somebody manages to poison [Function.prototype.call](https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/function-call.js) or `bind` nothing is safe, so I don't like this false claim that any polyfill out there is safer than others, it's always a matter of race conditions nobody can do anything about because that's how JS works: it's scripting, it's dynamic, one can play safe but it never really is (custom browsers with code injected AOT, extensions that might get a chance to taint the env before the page/module does, and so on)
  * measure performance impact of that `Reflect.apply` and if bad get rid of that false sense of security that gives this temporary module (until all browsers ship it natively) nothing useful at all for the real-world

That's it ... I might as well just drop *Reflct.apply* already before merging this MR as I don't really like the premises to have it in.