### PR TITLE
Fix #3 - Avoid collisions

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,16 @@ console.assert(JSON.stringify({ a: 1, b: 2 }, null) === '{"a":1,"b":2}');
 
 console.assert(JSON.stringify({ a: 1, b: 2 }, (_, v) => v) === '{"a":1,"b":2}');
 
+// issue #3 covered
+console.log(
+  JSON.parse('{"a":9007199254740993,"b":9007199254740992}', JSON.reviver),
+  '{ a: 9007199254740993n, b: 9007199254740992 }'
+);
+
+console.log(
+  JSON.parse('{"a":9007199254740992,"b":9007199254740993}', JSON.reviver),
+  '{ a: 9007199254740992, b: 9007199254740993n }'
+);
 
 // const s = JSON.rawJSON(JSON.stringify('Hello "there"!'));
 // JSON.parse(JSON.stringify({ s }), (key, value, context) => { console.log({ key, value, context }); return value });


### PR DESCRIPTION
As rightly pointed out in https://github.com/ungap/raw-json/issues/3 a *Map* as context was a bad idea due possible collision with numbers rounded to their nearest most representative value:

```js
9007199254740993 === 9007199254740992
// true
```

Pre-producing context references on already parsed values was not the way to go so that here:

  * the original text inverts all primitives:
    * strings become the only number in the JSON
    * booleans, numbers and null become the only strings
  * while revived:
    * values with typeof numbers returns as source string
    * all strings and newly retrieved numbers as string are passed as value, the source becomes free
  * I took the opportunity to also remove `Reflect.apply` as all I need is `call` and [everything I've said in here](https://github.com/ungap/raw-json/pull/2) still remains ... *TL;DR* I don't care about poisoned envs because it's not in this *ponyfill* that such issue can be solved and if `Function.prototype.call` has been poisoned anyone would have a way bigger issue to tackle in production
  * added tests that show correct results in bun and ponyfilled JSON

